### PR TITLE
tweak the repo url to point to the repo itself

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -67,7 +67,7 @@ my $builder = $class->new(
             bugtracker =>
               'http://rt.cpan.org/Public/Dist/Display.html?Name=Text-Textile-Plaintext',
             repository =>
-              'http://github.com/rjray/text-textile-plaintext/tree/master',
+              'http://github.com/rjray/text-textile-plaintext',
         }
     },
 


### PR DESCRIPTION
... as automated tools need the link to be pointing
to the repo, not its master tree, to do things like
cloning.
