### PR TITLE
add a local perlcritic rc file

### DIFF
--- a/t/05_critic.t
+++ b/t/05_critic.t
@@ -1,24 +1,13 @@
 #!/usr/bin/perl
 
-# Test that the module passes perlcritic
 use strict;
-BEGIN
-{
-    $|  = 1;
-    $^W = 1;
+use Test::More;
 
-    use Test::More;
-    unless ($ENV{AUTHOR_TESTING})
-    {
-        plan skip_all => "Author tests not required for installation";
-    }
-    else
-    {
-        eval "use Perl::Critic;";
-        eval "use Test::Perl::Critic;";
-    }
-}
+plan skip_all => "Author tests not required for installation"
+    unless $ENV{AUTHOR_TESTING};
+
+eval "require Test::Perl::Critic";
+
+Test::Perl::Critic->import( -profile => 't/perlcriticrc' );
 
 all_critic_ok();
-
-exit;

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -1,0 +1,1 @@
+theme = pbp


### PR DESCRIPTION
If not provided, the perlcritic test will pick any and every
critic rule installed on the machine (see RT#64333).

As a reasonable default, I've set the perlcritic configuration
to follow the PBP critic rules.
